### PR TITLE
Add Kea DHCP role

### DIFF
--- a/ansible/roles/kea-dhcp/defaults/main.yml
+++ b/ansible/roles/kea-dhcp/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for Kea DHCP
+
+ddns_update_style: none
+log_facility: local7
+

--- a/ansible/roles/kea-dhcp/handlers/main.yml
+++ b/ansible/roles/kea-dhcp/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+# Handlers file for Kea DHCP
+
+- name: reload kea-dhcp4-server
+  systemd:
+    state: reloaded
+    name: kea-dhcp4-server

--- a/ansible/roles/kea-dhcp/tasks/main.yml
+++ b/ansible/roles/kea-dhcp/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: main - Apt install kea-dhcp4-server
+  apt:
+    name: kea-dhcp4-server
+    state: present
+
+- name: main - Applying kea-dhcp4-server config file
+  template:
+    src: kea-dhcp4.conf.j2
+    dest: /etc/kea/kea-dhcp4.conf
+  notify: restart kea-dhcp4-server
+
+- name: main - Make sure kea-dhcp4-server is running
+  systemd:
+    state: started
+    name: kea-dhcp4-server

--- a/ansible/roles/kea-dhcp/templates/kea-dhcp4.conf.j2
+++ b/ansible/roles/kea-dhcp/templates/kea-dhcp4.conf.j2
@@ -1,0 +1,84 @@
+
+#
+# Configuration file for Kea DHCP
+#
+
+{
+    # DHCPv4 specific configuration starts here.
+    "Dhcp4": {
+
+{% if (authoritative is defined and authoritative == true) %}
+        "authoritative": true
+{% endif %}
+
+        "interfaces-config": {
+            "interfaces": [ "{{ interfaces }}" ],
+            "dhcp-socket-type": "raw"
+        },
+
+{% if default_lease_time is defined %}
+        "valid-lifetime": {{ default_lease_time }},
+{% endif %}
+
+        "subnet4": [
+{% for subnet in subnets %}
+
+            # Subnet: {{ subnet.comment }}
+{% if subnet.option is defined %}
+            {
+
+               "subnet": "{{ subnet.subnet }}/{{ subnet.cidr_mask }}",
+
+{% if subnet.default_lease_time is defined %}
+               "valid-lifetime": {{ subnet.default_lease_time }},
+{% endif %}
+
+               "pools": [ { "pool": "{{ subnet.range_from }}-{{ subnet.range_to }}" } ],
+
+               "option-data": [
+
+{% if subnet.option.domain_name is defined %}
+                    {
+                         "name": "domain-name",
+                         "data": "{{ subnet.option.domain_name }}"
+                    },
+{% endif %}
+
+{% if subnet.option.domain_name_servers is defined %}
+                    {
+                         "name": "domain-name-servers",
+                         "data": "{{ subnet.option.domain_name_servers | join(", ") }}"
+                    },
+{% endif %}
+
+{% if subnet.option.routers is defined %}
+                    {
+                        "name": "routers",
+                        "data": "{{ subnet.option.routers }}"
+                    }
+{% endif %}
+                ]
+{% if not loop.last %}
+            },
+{% else %}
+            }
+{% endif %}
+
+{% else %}
+            {
+               "subnet": "{{ subnet.subnet }}/{{ subnet.cidr_mask }}"
+            },
+{% endif %}
+{% endfor %}
+        ]
+    },
+
+    # Logger configuration starts here.
+    "Logging": {
+       "loggers": [{
+            "name": "*",
+            "severity": "INFO"
+        }]
+    }
+
+}


### PR DESCRIPTION
This role deploys Kea DHCP in a Standalone mode, basically it behaves exactly
the old ISC DHCP also in Standalome mode.

This way, we can deploy both, side by side, and switch between them by just
moving the "VIP" (IP Alias today) across the Machines.